### PR TITLE
DRTII-1360 Validate letters for postal code validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "description": "Extended validators for zod.",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/bracketlab/zod-extended-validators"

--- a/src/validation.fields.ts
+++ b/src/validation.fields.ts
@@ -17,6 +17,14 @@ export const postalCodeField = (customError?: EValidationErrors) => {
   return z
     .string()
     .length(5, {
+      message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE
+    }).or(z.string().optional())
+}
+
+export const onlyNumberPostalCodeField = (customError?: EValidationErrors) => {
+  return z
+    .string()
+    .length(5, {
       message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE,
     })
     .regex(/^\d*$/, {
@@ -69,6 +77,12 @@ export const requiredBooleanField = (customError?: EValidationErrors) => {
 }
 
 export const requiredPostalCodeField = (customError?: EValidationErrors) => {
+  return z.string().length(5, {
+    message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE
+  })
+}
+
+export const requiredOnlyNumberPostalCodeField = (customError?: EValidationErrors) => {
   return z
     .string()
     .length(5, {

--- a/src/validation.fields.ts
+++ b/src/validation.fields.ts
@@ -17,9 +17,20 @@ export const postalCodeField = (customError?: EValidationErrors) => {
   return z
     .string()
     .length(5, {
-      message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE
-    }).or(z.string().optional())
-}
+      message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE,
+    })
+    .regex(/^\d*$/, {
+      message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE,
+    })
+    .or(
+      z
+        .string()
+        .regex(/^\d*$/, {
+          message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE,
+        })
+        .optional()
+    );
+};
 
 export const requiredTextField = (customError?: EValidationErrors) => {
   return z
@@ -58,10 +69,15 @@ export const requiredBooleanField = (customError?: EValidationErrors) => {
 }
 
 export const requiredPostalCodeField = (customError?: EValidationErrors) => {
-  return z.string().length(5, {
-    message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE
-  })
-}
+  return z
+    .string()
+    .length(5, {
+      message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE,
+    })
+    .regex(/^\d*$/, {
+      message: customError ?? EValidationErrors.ERROR_INVALID_POSTAL_CODE,
+    });
+};
 
 export const requiredPhoneNumberField = (customError?: EValidationErrors) => {
   const numericPattern = /^\d+$/


### PR DESCRIPTION
Here is the main purpose of the change: https://linear.app/bracketlab/issue/DRTII-1360/bug-letters-are-valid-for-postal-code